### PR TITLE
Expand test matrix to inlcude golang 1.12, 1.13, 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 sudo: required
 go:
   - "1.11"
+  - "1.12"
+  - "1.13"
+  - "1.14"
 
 env:
   - GO111MODULE=on AWS_ACCESS_KEY_ID=AKID AWS_SECRET_ACCESS_KEY=SECRET


### PR DESCRIPTION
This PR expands the test matrix to include golang versions 1.12-1.14 as well. 